### PR TITLE
Remove tests checking if service is defined

### DIFF
--- a/src/services/book-condition/book-condition.service.spec.ts
+++ b/src/services/book-condition/book-condition.service.spec.ts
@@ -9,10 +9,6 @@ describe('BookConditionService', () => {
     bookConditionService = await getService(BookConditionService);
   });
 
-  it('should be defined', () => {
-    expect(bookConditionService).toBeDefined();
-  });
-
   it('should check if book conditions exist', async () => {
     // exists
     const exists1 = await bookConditionService.bookConditionExists(3);

--- a/src/services/book/book.service.spec.ts
+++ b/src/services/book/book.service.spec.ts
@@ -39,10 +39,6 @@ describe('BookService', () => {
     await userService.deleteUser(user.id);
   });
 
-  it('should be defined', () => {
-    expect(bookService).toBeDefined();
-  });
-
   it('should create and delete books', async () => {
     // create
     const book1 = await bookService.createBook({

--- a/src/services/db/db.service.spec.ts
+++ b/src/services/db/db.service.spec.ts
@@ -10,10 +10,6 @@ describe('DBService', () => {
     dbService = await getService(DBService);
   });
 
-  it('should be defined', () => {
-    expect(dbService).toBeDefined();
-  });
-
   it('should create and get/update/delete by ID', async () => {
     // create
     const imageData = 'abcde';

--- a/src/services/department/department.service.spec.ts
+++ b/src/services/department/department.service.spec.ts
@@ -9,10 +9,6 @@ describe('DepartmentService', () => {
     departmentService = await getService(DepartmentService);
   });
 
-  it('should be defined', () => {
-    expect(departmentService).toBeDefined();
-  });
-
   it('should check if departments exist', async () => {
     // exists
     const exists1 = await departmentService.departmentExists(17);

--- a/src/services/feedback/feedback.service.spec.ts
+++ b/src/services/feedback/feedback.service.spec.ts
@@ -29,10 +29,6 @@ describe('FeedbackService', () => {
     await userService.deleteUser(user.id);
   });
 
-  it('should be defined', () => {
-    expect(feedbackService).toBeDefined();
-  });
-
   it('should send and delete feedback', async () => {
     // send invalid feedback
     await expect(feedbackService.sendFeedback(user.id, '')).rejects.toThrow(

--- a/src/services/image/image.service.spec.ts
+++ b/src/services/image/image.service.spec.ts
@@ -9,10 +9,6 @@ describe('ImageService', () => {
     imageService = await getService(ImageService);
   });
 
-  it('should be defined', () => {
-    expect(imageService).toBeDefined();
-  });
-
   it('should create, check existence, and delete an image', async () => {
     // create
     const imageData = 'abc';

--- a/src/services/message/message.service.spec.ts
+++ b/src/services/message/message.service.spec.ts
@@ -34,10 +34,6 @@ describe('MessageService', () => {
     await userService.deleteUser(user2.id);
   });
 
-  it('should be defined', () => {
-    expect(messageService).toBeDefined();
-  });
-
   it('should send, check existence, get, and delete messages', async () => {
     // send
     const message1 = await messageService.sendMessage(

--- a/src/services/password-reset/password-reset.service.spec.ts
+++ b/src/services/password-reset/password-reset.service.spec.ts
@@ -12,10 +12,6 @@ describe('PasswordResetService', () => {
     userService = await getService(UserService);
   });
 
-  it('should be defined', () => {
-    expect(passwordResetService).toBeDefined();
-  });
-
   it('should create, check existence, and delete password resets', async () => {
     // create
     const firstname = 'Martin';

--- a/src/services/referral/referral.service.spec.ts
+++ b/src/services/referral/referral.service.spec.ts
@@ -35,10 +35,6 @@ describe('ReferralService', () => {
     await userService.deleteUser(user3.id);
   });
 
-  it('should be defined', () => {
-    expect(referralService).toBeDefined();
-  });
-
   it('should refer, get referral, get referrals, and delete referrals', async () => {
     // refer
     const referral1 = await referralService.referUser(user1.id, user2.id);

--- a/src/services/report/report.service.spec.ts
+++ b/src/services/report/report.service.spec.ts
@@ -65,10 +65,6 @@ describe('ReportService', () => {
     await userService.deleteUser(user.id);
   });
 
-  it('should be defined', () => {
-    expect(reportService).toBeDefined();
-  });
-
   it('should create, check existence, get, and delete a report', async () => {
     // create with error
     await expect(

--- a/src/services/resource/resource.service.spec.ts
+++ b/src/services/resource/resource.service.spec.ts
@@ -8,10 +8,6 @@ describe('ResourceService', () => {
     resourceService = await getService(ResourceService);
   });
 
-  it('should be defined', () => {
-    expect(resourceService).toBeDefined();
-  });
-
   it('should check if resources exist', async () => {
     // exists
     const exists1 = await resourceService.resourceExists('SALT_ROUNDS');

--- a/src/services/search-sort/search-sort.service.spec.ts
+++ b/src/services/search-sort/search-sort.service.spec.ts
@@ -9,10 +9,6 @@ describe('SearchSortService', () => {
     searchSortService = await getService(SearchSortService);
   });
 
-  it('should be defined', () => {
-    expect(searchSortService).toBeDefined();
-  });
-
   it('should check if a search sort option exists', async () => {
     // check existence
     const exists1 = await searchSortService.sortOptionExists(2);

--- a/src/services/session/session.service.spec.ts
+++ b/src/services/session/session.service.spec.ts
@@ -12,10 +12,6 @@ describe('SessionService', () => {
     userService = await getService(UserService);
   });
 
-  it('should be defined', () => {
-    expect(sessionService).toBeDefined();
-  });
-
   it('should create, check existence, get, and delete a session', async () => {
     // create
     const firstname = 'Martin';

--- a/src/services/user-interest/user-interest.service.spec.ts
+++ b/src/services/user-interest/user-interest.service.spec.ts
@@ -27,10 +27,6 @@ describe('UserInterestService', () => {
     await userService.deleteUser(user.id);
   });
 
-  it('should be defined', () => {
-    expect(userInterestService).toBeDefined();
-  });
-
   it('should note interest, check if interested, and drop interest', async () => {
     // note interest
     const departmentID = 15;

--- a/src/services/user/user.service.spec.ts
+++ b/src/services/user/user.service.spec.ts
@@ -9,10 +9,6 @@ describe('UserService', () => {
     userService = await getService(UserService);
   });
 
-  it('should be defined', () => {
-    expect(userService).toBeDefined();
-  });
-
   it('should create, check existence, get, get books, and delete a user', async () => {
     // create
     const firstname = 'Martin';

--- a/src/services/verify/verify.service.spec.ts
+++ b/src/services/verify/verify.service.spec.ts
@@ -12,10 +12,6 @@ describe('VerifyService', () => {
     userService = await getService(UserService);
   });
 
-  it('should be defined', () => {
-    expect(verifyService).toBeDefined();
-  });
-
   it('should create, check existence, and delete verifications', async () => {
     // create
     const firstname = 'Martin';


### PR DESCRIPTION
Errors will be thrown if services are not defined, so we do not need to test if they are defined.