### PR TITLE
Prevent pip install with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "postinstall": "cd app && npm install && cd .. && python3 -m pip install -r requirements.txt",
+    "postinstall": "cd app && npm install",
     "prebuild": "rimraf dist",
     "build": "npm run build:frontend && npm run build:backend",
     "build:backend": "nest build",


### PR DESCRIPTION
This fixes a Heroku build issue. Attempting to install Python packages with pip upon `npm install` causes the build to fail. Heroku should automatically install Python packages using `requirements.txt`.